### PR TITLE
fix: PortfolioPhoto 엔티티 photoOrder 필드 추가 및 미사용 필드 삭제 

### DIFF
--- a/src/main/java/com/hm/picplz/domain/portfolio/domain/PortfolioPhoto.java
+++ b/src/main/java/com/hm/picplz/domain/portfolio/domain/PortfolioPhoto.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,27 +25,21 @@ public class PortfolioPhoto extends BaseEntity {
     private Long id;
 
     @NotNull
-    private String imageData;
+    private String image;
 
-    @NotNull
-    private String location;
-
-    @NotNull
-    private LocalDateTime uploadDate;
+    @Column(name = "photo_order")
+    private int photoOrder;
 
     @ManyToOne
     @JoinColumn(name = "portfolio_id", nullable = false)
     private Portfolio portfolio;
 
     @Builder
-    private PortfolioPhoto(Long id, String imageData, String location, LocalDateTime uploadDate,
-        Portfolio portfolio) {
+    private PortfolioPhoto(Long id, String image, int photoOrder, Portfolio portfolio) {
         this.id = id;
-        this.imageData = imageData;
-        this.location = location;
-        this.uploadDate = uploadDate;
+        this.image = image;
+        this.photoOrder = photoOrder;
         this.portfolio = portfolio;
     }
-
     // factory method
 }


### PR DESCRIPTION
# 💡 PR Summary - PortfolioPhoto 엔티티 photoOrder 필드 추가 및 미사용 필드 삭제 
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
PortfolioPhoto 엔티티 photoOrder 필드 추가 및 미사용 필드 삭제 

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
fix/portfolio

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- close #23
