### PR TITLE
[feat] 법정동 테이블 생성

### DIFF
--- a/src/main/java/com/hm/picplz/domain/area/domain/Area.java
+++ b/src/main/java/com/hm/picplz/domain/area/domain/Area.java
@@ -1,0 +1,53 @@
+package com.hm.picplz.domain.area.domain;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.hm.picplz.domain.photographer.domain.ActiveArea;
+import com.hm.picplz.global.common.entity.BaseEntity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Area extends BaseEntity {
+	@Id
+	@Column(name = "area_id", updatable = false)
+	private Long id;
+
+	private String sido;
+
+	private String sigungu;
+
+	private String eupmyeondong;
+
+	private String ri;
+
+	private String name;
+
+	@Column(name = "area_order") // 데이터에 존재하는 '순위'
+	private Integer areaOrder;
+
+	@Column(name = "created_date")
+	private LocalDate createdDate;
+
+	@Column(name = "deleted_date")
+	private LocalDate deletedDate;
+
+	@Column(name = "old_code")
+	private Long oldCode;
+
+	@OneToMany(mappedBy = "area", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	private List<ActiveArea> activeAreas = new ArrayList<>();
+
+}

--- a/src/main/java/com/hm/picplz/domain/photographer/controller/PhotographerController.java
+++ b/src/main/java/com/hm/picplz/domain/photographer/controller/PhotographerController.java
@@ -3,8 +3,8 @@ package com.hm.picplz.domain.photographer.controller;
 import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,23 +48,23 @@ public class PhotographerController {
     }
 
 
-    @PhotographerOnly
-    @Operation(summary = "작가 경력 추가")
-    @PostMapping("/career")
-    public void updatePhotographerCareer(
-        @AuthenticationPrincipal Long memberId,
-        @RequestBody PhotographerDto.AddCareer addCareerRequestDto) {
-        photographerService.addCareer(addCareerRequestDto, memberId);
-    }
-
-    @PhotographerOnly
-    @Operation(summary = "작가 경력 기간 수정")
-    @PatchMapping("/period")
-    public void updatePhotographerCareerPeriod(
-        @AuthenticationPrincipal Long memberId,
-        @RequestBody PhotographerDto.UpdateCareerPeriod updateCareerPeriodRequestDto) {
-        photographerService.updateCareerPeriod(updateCareerPeriodRequestDto, memberId);
-    }
+    // @PhotographerOnly
+    // @Operation(summary = "작가 경력 추가")
+    // @PostMapping("/career")
+    // public void updatePhotographerCareer(
+    //     @AuthenticationPrincipal Long memberId,
+    //     @RequestBody PhotographerDto.AddCareer addCareerRequestDto) {
+    //     photographerService.addCareer(addCareerRequestDto, memberId);
+    // }
+    //
+    // @PhotographerOnly
+    // @Operation(summary = "작가 경력 기간 수정")
+    // @PatchMapping("/period")
+    // public void updatePhotographerCareerPeriod(
+    //     @AuthenticationPrincipal Long memberId,
+    //     @RequestBody PhotographerDto.UpdateCareerPeriod updateCareerPeriodRequestDto) {
+    //     photographerService.updateCareerPeriod(updateCareerPeriodRequestDto, memberId);
+    // }
 
     @PhotographerOnly
     @Operation(summary = "사진 감성 해시 태그 생성")
@@ -84,7 +84,7 @@ public class PhotographerController {
         return photographerService.getPhotographerDetail(photographerId, memberId);
     }
 
-    @Operation(summary = "활영 상품 리스트 조회")
+    @Operation(summary = "촬영 상품 리스트 조회")
     @GetMapping("/{photographerId}/products")
     public List<Detail> loadProductsByPhotographerId(
             @PathVariable(name = "photographerId") Long photographerId

--- a/src/main/java/com/hm/picplz/domain/photographer/domain/ActiveArea.java
+++ b/src/main/java/com/hm/picplz/domain/photographer/domain/ActiveArea.java
@@ -1,0 +1,62 @@
+package com.hm.picplz.domain.photographer.domain;
+
+import com.hm.picplz.domain.area.domain.Area;
+import com.hm.picplz.global.common.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActiveArea extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "active_area_id", updatable = false)
+	private Long id;
+
+	// Photographer와의 다대일 관계
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "photographer_id")
+	private Photographer photographer;
+
+	// Area와의 다대일 관계
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "area_id")
+	private Area area;
+
+	private String sido;
+
+	private String sigungu;
+
+	private String eupmyeondong;
+
+	private String ri;
+
+	private String name;
+
+	private Integer priority; // 작가 활동 지역 우선순위
+
+	@Builder
+	public ActiveArea(Photographer photographer, Area area, String sido, String sigungu,
+		String eupmyeondong, String ri, String name, Integer priority) {
+		this.photographer = photographer;
+		this.area = area;
+		this.sido = sido;
+		this.sigungu = sigungu;
+		this.eupmyeondong = eupmyeondong;
+		this.ri = ri;
+		this.name = name;
+		this.priority = priority;
+	}
+}

--- a/src/main/java/com/hm/picplz/domain/photographer/domain/Photographer.java
+++ b/src/main/java/com/hm/picplz/domain/photographer/domain/Photographer.java
@@ -1,70 +1,77 @@
 package com.hm.picplz.domain.photographer.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.hm.picplz.domain.member.domain.Member;
 import com.hm.picplz.domain.product.domain.ShootProduct;
 import com.hm.picplz.domain.review.domain.Review;
 import com.hm.picplz.global.common.entity.BaseEntity;
 import com.hm.picplz.global.common.entity.YesNo;
-import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Photographer extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "photographer_id", updatable = false)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "photographer_id", updatable = false)
+	private Long id;
 
-    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "member_id")
-    private Member member;
+	@OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+	@JoinColumn(name = "member_id")
+	private Member member;
 
-    @NotNull
-    private String area;
+	private int period; // 1년 3개월 -> 15개월
 
-    private int period; // 1년 3개월 -> 15개월
+	private YesNo active;  // Y/N
 
-    private YesNo active;  // Y/N
+	private String instagram; // 인스타그램 아이디
 
-    private String instagram; // 인스타그램 아이디
+	private String introduction; // 소갯말
 
-    private String introduction; // 소갯말
+	@OneToMany(mappedBy = "photographer", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	private List<ShootProduct> shootProducts = new ArrayList<>();
 
-    @OneToMany(mappedBy = "photographer", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    private List<ShootProduct> shootProducts = new ArrayList<>();
+	@OneToMany(mappedBy = "photographer", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	private List<Review> reviews = new ArrayList<>();
 
-    @OneToMany(mappedBy = "photographer", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    private List<Review> reviews = new ArrayList<>();
+	@OneToMany(mappedBy = "photographer", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	private List<PhotoMood> photoMoods = new ArrayList<>();
 
-    @OneToMany(mappedBy = "photographer", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    private List<PhotoMood> photoMoods = new ArrayList<>();
+	@OneToMany(mappedBy = "photographer", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	private List<Career> careers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "photographer", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    private List<Career> careers = new ArrayList<>();
+	@OneToMany(mappedBy = "photographer", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	private List<ActiveArea> activeAreas = new ArrayList<>();
 
-    @Builder
-    private Photographer(Long id, Member member, String area,int period, YesNo active,
-        String instagram, String introduction) {
-        this.id = id;
-        this.member = member;
-        this.area = area;
-        this.period = period;
-        this.active = active;
-        this.instagram = instagram;
-        this.introduction = introduction;
-    }
+	@Builder
+	private Photographer(Long id, Member member, int period, YesNo active, String instagram, String introduction) {
+		this.id = id;
+		this.member = member;
+		this.period = period;
+		this.active = active;
+		this.instagram = instagram;
+		this.introduction = introduction;
+	}
 
-    public void updatePeriod(int period) {
-        this.period = period;
-    }
+	public void updatePeriod(int period) {
+		this.period = period;
+	}
 }

--- a/src/main/java/com/hm/picplz/domain/photographer/dto/PhotographerDto.java
+++ b/src/main/java/com/hm/picplz/domain/photographer/dto/PhotographerDto.java
@@ -1,7 +1,9 @@
 package com.hm.picplz.domain.photographer.dto;
 
+import java.util.Comparator;
 import java.util.List;
 
+import com.hm.picplz.domain.photographer.domain.ActiveArea;
 import com.hm.picplz.domain.photographer.domain.CareerType;
 import com.hm.picplz.domain.photographer.domain.PhotoMood;
 import com.hm.picplz.domain.photographer.domain.Photographer;
@@ -49,7 +51,7 @@ public class PhotographerDto {
         private Long photographerId;
         private String nickname;
         private String profileImage;
-        private String area;
+        private List<ActiveAreaRes> area;
         private String introduction;
         private YesNo active;
         private String instagram;
@@ -62,7 +64,10 @@ public class PhotographerDto {
             detail.photographerId = photographer.getId();
             detail.nickname = photographer.getMember().getNickname();
             detail.profileImage = photographer.getMember().getProfileImage();
-            detail.area = photographer.getArea();
+            detail.area = photographer.getActiveAreas().stream()
+                .map(ActiveAreaRes::of)
+                .sorted(Comparator.comparingInt(ActiveAreaRes::getPriority))
+                .toList();
             detail.active = photographer.getActive();
             detail.instagram = photographer.getInstagram();
             detail.photoMoods = photographer.getPhotoMoods().stream()
@@ -77,29 +82,53 @@ public class PhotographerDto {
 
     @Data
     @NoArgsConstructor
+    public static class ActiveAreaRes {
+        private Long code;
+        private String name;
+        private Integer priority;
+
+        public static ActiveAreaRes of(ActiveArea activeArea) {
+            ActiveAreaRes activeAreaRes = new ActiveAreaRes();
+            activeAreaRes.code     = activeArea.getArea().getId();
+            activeAreaRes.name     = activeArea.getName();
+            activeAreaRes.priority = activeArea.getPriority();
+            return activeAreaRes;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
     public static class Create {
-        private String area;
         private int year;
         private int month;
         private String instagram;
         private String introduction;
         private List<String> photoMoods;
+        private List<ActiveAreaReq> activeAreas;
 
-        public static Create of (String area, int year, int month, String instagram, String introduction, List<String> photoMoods) {
+        public static Create of (int year, int month, String instagram, String introduction, List<String> photoMoods,
+            List<ActiveAreaReq> activeAreas) {
             Create create = new Create();
-            create.area = area;
             create.year = year;
             create.month = month;
             create.instagram = instagram;
             create.introduction = introduction;
             create.photoMoods = photoMoods;
+            create.activeAreas = activeAreas;
 
             return create;
         }
     }
 
     @Data
-    @NoArgsConstructor()
+    @NoArgsConstructor
+    public static class ActiveAreaReq {
+        private Long code;
+        private Integer priority;
+    }
+
+    @Data
+    @NoArgsConstructor
     public static class AddCareer {
         private List<CareerType> careers;
 

--- a/src/main/java/com/hm/picplz/domain/photographer/exception/PhotographerErrorCode.java
+++ b/src/main/java/com/hm/picplz/domain/photographer/exception/PhotographerErrorCode.java
@@ -18,7 +18,13 @@ public enum PhotographerErrorCode implements BaseErrorCode {
     PHOTOGRAPHER_NOT_FOUND(BAD_REQUEST, "PHOTOGRAPHER_404_1", "해당 작가가 존재하지 않습니다."),
 
     /* Career */
-    WRONG_CAREER_TYPE(BAD_REQUEST, "CAREER_400_1", "유효하지 않은 경력 유형입니다.")
+    WRONG_CAREER_TYPE(BAD_REQUEST, "CAREER_400_1", "유효하지 않은 경력 유형입니다."),
+
+    /* Area */
+    WRONG_AREA_CODE(BAD_REQUEST, "AREA_400_1", "유효하지 않은 법정동 정보입니다."),
+
+    /* PhotoMood */
+    PHOTOMOOD_NOT_FOUND(BAD_REQUEST, "PHOTOMOOD_404_1", "해당 사진 감성이 존재하지 않습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/hm/picplz/domain/photographer/repository/ActiveAreaRepository.java
+++ b/src/main/java/com/hm/picplz/domain/photographer/repository/ActiveAreaRepository.java
@@ -1,0 +1,8 @@
+package com.hm.picplz.domain.photographer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hm.picplz.domain.photographer.domain.ActiveArea;
+
+public interface ActiveAreaRepository extends JpaRepository<ActiveArea, Long> {
+}

--- a/src/main/java/com/hm/picplz/domain/photographer/repository/AreaRepoisotry.java
+++ b/src/main/java/com/hm/picplz/domain/photographer/repository/AreaRepoisotry.java
@@ -1,0 +1,8 @@
+package com.hm.picplz.domain.photographer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hm.picplz.domain.area.domain.Area;
+
+public interface AreaRepoisotry extends JpaRepository<Area, Long> {
+}

--- a/src/main/java/com/hm/picplz/domain/photographer/service/PhotographerService.java
+++ b/src/main/java/com/hm/picplz/domain/photographer/service/PhotographerService.java
@@ -7,15 +7,19 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.hm.picplz.domain.area.domain.Area;
 import com.hm.picplz.domain.following.repository.FollowingRepository;
 import com.hm.picplz.domain.member.MemberRepository;
 import com.hm.picplz.domain.member.domain.Member;
 import com.hm.picplz.domain.member.exception.MemberErrorCode;
+import com.hm.picplz.domain.photographer.domain.ActiveArea;
 import com.hm.picplz.domain.photographer.domain.Career;
 import com.hm.picplz.domain.photographer.domain.Photographer;
 import com.hm.picplz.domain.photographer.dto.PhotoMoodDto;
 import com.hm.picplz.domain.photographer.dto.PhotographerDto;
 import com.hm.picplz.domain.photographer.exception.PhotographerErrorCode;
+import com.hm.picplz.domain.photographer.repository.ActiveAreaRepository;
+import com.hm.picplz.domain.photographer.repository.AreaRepoisotry;
 import com.hm.picplz.domain.photographer.repository.CareerRepository;
 import com.hm.picplz.domain.photographer.repository.PhotographerRepository;
 import com.hm.picplz.global.common.entity.YesNo;
@@ -33,6 +37,8 @@ public class PhotographerService {
 	private final PhotographerRepository photographerRepository;
 	private final MemberRepository memberRepository;
 	private final FollowingRepository followingRepository;
+	private final ActiveAreaRepository activeAreaRepository;
+	private final AreaRepoisotry areaRepoisotry;
 
 	private final RedisTemplate<String, Object> redisTemplate;
 
@@ -45,7 +51,6 @@ public class PhotographerService {
 
 		Photographer photographer = Photographer.builder()
 			.member(member)
-			.area(createPhotographerRequestDto.getArea())
 			.period(createPhotographerRequestDto.getYear() * 12 + createPhotographerRequestDto.getMonth())
 			.active(YesNo.N)
 			.instagram(createPhotographerRequestDto.getInstagram())
@@ -53,7 +58,28 @@ public class PhotographerService {
 			.build();
 
 		photographerRepository.save(photographer);
-		photoMoodService.createPhotoMood(createPhotographerRequestDto.getPhotoMoods(), photographer);
+		photoMoodService.createPhotoMoods(createPhotographerRequestDto.getPhotoMoods(), photographer);
+		createActiveAreas(createPhotographerRequestDto.getActiveAreas(), photographer);
+	}
+
+	private void createActiveAreas(List<PhotographerDto.ActiveAreaReq> areaDtos, Photographer photographer) {
+		for (PhotographerDto.ActiveAreaReq dto : areaDtos) {
+			Area area = areaRepoisotry.findById(dto.getCode())
+				.orElseThrow(() -> ExceptionFactory.of(PhotographerErrorCode.WRONG_AREA_CODE));
+
+			ActiveArea activeArea = ActiveArea.builder()
+				.photographer(photographer)
+				.area(area)
+				.sido(area.getSido())
+				.sigungu(area.getSigungu())
+				.eupmyeondong(area.getEupmyeondong())
+				.ri(area.getRi())
+				.name(area.getName())
+				.priority(dto.getPriority())
+				.build();
+
+			activeAreaRepository.save(activeArea);
+		}
 	}
 
 	public PhotographerDto.Detail getPhotographerDetail(Long photographerId, Long memberId) {

--- a/src/main/resources/data/insert_db.sh
+++ b/src/main/resources/data/insert_db.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# ======================
+# ✨ 설정 부분 (필수로 수정)
+# ======================
+USER=""                     # MySQL 사용자명
+PASSWORD=""       # 비밀번호
+DATABASE="picplz"       # DB 이름
+TABLE="area"           # 테이블 이름
+CSV_FILE="국토교통부_전국 법정동_20250415.csv"          # CSV 파일명
+START_LINE=2                   # 시작 줄 번호 (1 = 헤더니까 2부터)
+
+
+# ======================
+# ✅ 실행 시작
+# ======================
+CURRENT_LINE=$((START_LINE - 1))
+
+# 문자열 값이 비어있으면 NULL, 아니면 '값'으로 반환
+sql_string_or_null() {
+  local val="$1"
+  if [[ -z "$val" ]]; then
+    echo "NULL"
+  else
+    # 작은따옴표 이스케이프 처리
+    val="${val//\'/\\\'}"
+    echo "'$val'"
+  fi
+}
+
+tail -n +$START_LINE "$CSV_FILE" | while IFS=',' read -r -a row
+do
+  ((CURRENT_LINE++))
+
+  # 누락 필드 보정: 배열 길이 < 9일 경우 빈 값 추가
+  for ((i=${#row[@]}; i<9; i++)); do
+    row[i]=""
+  done
+
+  # 각 필드 매핑
+  id="${row[0]}"
+  sido="${row[1]}"
+  sigungu="${row[2]}"
+  eup="${row[3]}"
+  ri="${row[4]}"
+  order="${row[5]}"
+  created="${row[6]}"
+  deleted="${row[7]}"
+  old_code="${row[8]}"
+
+  # 🧼 CR 문자 제거 (숨겨진 원인 제거!)
+  deleted=$(echo "$deleted" | tr -d '\r')
+  old_code=$(echo "$old_code" | tr -d '\r')
+
+  # 필수값 확인
+  if [[ -z "$id" || -z "$sido" ]]; then
+    echo "🚫 필수값 누락 (줄 $CURRENT_LINE), 건너뜀"
+    continue
+  fi
+
+  # name 생성 (sido는 무조건, 이후 값이 있을 때만 추가)
+  name="$sido"
+  if [[ -n "$sigungu" ]]; then
+    name+=" $sigungu"
+  else
+    echo
+    # sigungu가 없으면 eup, ri도 무시 (sido만 name에)
+    name="$sido"
+  fi
+  if [[ -n "$eup" ]]; then
+    name+=" $eup"
+  fi
+  if [[ -n "$ri" ]]; then
+    name+=" $ri"
+  fi
+
+  # 문자열/NULL 처리
+  sigungu_sql=$(sql_string_or_null "$sigungu")
+  eup_sql=$(sql_string_or_null "$eup")
+  ri_sql=$(sql_string_or_null "$ri")
+  name_sql=$(sql_string_or_null "$name")
+  sido_sql=$(sql_string_or_null "$sido")
+
+  # 숫자 및 날짜/NULL 처리
+  [[ -z "$order" ]] && order_sql="NULL" || order_sql="$order"
+  [[ -z "$created" ]] && created_sql="NULL" || created_sql="STR_TO_DATE('$created', '%Y-%m-%d')"
+  [[ -z "$deleted" ]] && deleted_sql="NULL" || deleted_sql="STR_TO_DATE('$deleted', '%Y-%m-%d')"
+  [[ -z "$old_code" ]] && old_code_sql="NULL" || old_code_sql="$old_code"
+
+  # SQL 구문
+  SQL="INSERT INTO $TABLE (
+    id, sido, sigungu, eupmyeondong, ri, name,
+    area_order, created_date, deleted_date, old_code
+  ) VALUES (
+    $id, $sido_sql, $sigungu_sql, $eup_sql, $ri_sql, $name_sql, $order_sql, $created_sql, $deleted_sql, $old_code_sql
+  );"
+
+  echo "$SQL"  # 필요 시 SQL 직접 확인
+
+  # 쿼리 실행
+  mysql -u "$USER" -p"$PASSWORD" "$DATABASE" -e "$SQL"
+
+  if [ $? -ne 0 ]; then
+    echo "❌ 실패! 줄 번호: $CURRENT_LINE"
+    echo "🔁 다시 시작하려면: START_LINE=$CURRENT_LINE"
+    exit 1
+  fi
+
+  echo "✅ 성공: 줄 $CURRENT_LINE"
+
+done


### PR DESCRIPTION
# 💡 PR Summary - 법정동 데이터 추가
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
작업 사항
- 법정동 지역(Area) 정보 테이블 생성
- 관계 테이블(ActiveArea) 생성
- 데이터 삽입 스크립트 추가
  1. 로컬 DB에 스크립트로 데이터를 넣어둔다.
  2. 서버 DB에 DBeaver를 활용해 테이블 째로 옮긴다.
- 작가 활동지역
  - 작가 가입시 활동지역을 법정동 코드, 우선순위와 함께 전달받음
  - 작가 조회시 활동지역 우선순위에 따라 반환
  - 작가 활동지역 수정 추후 구현
- 오타 수정

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
feat/area

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- close #40 
- close #47
