### PR TITLE
[fix] KAKAO 로그인 ID Long -> String 정상 파싱하도록 수정

### DIFF
--- a/src/main/java/com/hm/picplz/domain/auth/service/AuthService.java
+++ b/src/main/java/com/hm/picplz/domain/auth/service/AuthService.java
@@ -87,7 +87,7 @@ public class AuthService {
 		if (body == null) {
 			throw ExceptionFactory.of(MemberErrorCode.NO_KAKAO_USER);
 		}
-		String code = (String) body.get("id"); // 필수 값
+		String code = String.valueOf(body.get("id")); // 필수 값
 
 		// 카카오 앱이 비즈앱이 아니라 email 수집을 강제할 수 없어, email 파싱 코드는 생략했습니다.
 		// (비즈앱 전환 후 아래 로직 참고: kakao_account에서 email 가져오기)


### PR DESCRIPTION
# 💡 PR Summary - <!--{ 작업 내용 }--> KAKAO 로그인 ID Long -> String 정상 파싱하도록 수정
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
ID 파싱 시 String 으로 형변환 하지 않고 String.valueOf 를 통해서 변경하도록 수정

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
fix/kakao

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- close #77 
