### PR TITLE
[feat] 전국 읍면동 조회 API 구현

### DIFF
--- a/src/main/java/com/hm/picplz/domain/area/controller/AreaController.java
+++ b/src/main/java/com/hm/picplz/domain/area/controller/AreaController.java
@@ -36,4 +36,10 @@ public class AreaController {
 	public List<AreaDto.AreaInfo> searchAreasWithKeyword(@RequestParam String keyword) {
 		return areaService.searchAreasWithKeyword(keyword);
 	}
+
+	@Operation(summary = "모든 법정동 조회")
+	@GetMapping()
+	public List<AreaDto.AllAreaInfo> getAllAreas() {
+		return areaService.getAllAreas();
+	}
 }

--- a/src/main/java/com/hm/picplz/domain/area/dto/AllAreaInfoProjection.java
+++ b/src/main/java/com/hm/picplz/domain/area/dto/AllAreaInfoProjection.java
@@ -1,0 +1,7 @@
+package com.hm.picplz.domain.area.dto;
+
+public interface AllAreaInfoProjection {
+    String getSido();
+    String getSigungu();
+    String getEupmyeondong();
+}

--- a/src/main/java/com/hm/picplz/domain/area/dto/AllAreaInfoProjection.java
+++ b/src/main/java/com/hm/picplz/domain/area/dto/AllAreaInfoProjection.java
@@ -3,5 +3,5 @@ package com.hm.picplz.domain.area.dto;
 public interface AllAreaInfoProjection {
     String getSido();
     String getSigungu();
-    String getEupmyeondong();
+    String getNeighborhoods();
 }

--- a/src/main/java/com/hm/picplz/domain/area/dto/AreaDto.java
+++ b/src/main/java/com/hm/picplz/domain/area/dto/AreaDto.java
@@ -2,10 +2,9 @@ package com.hm.picplz.domain.area.dto;
 
 import com.hm.picplz.domain.area.domain.Area;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,5 +26,21 @@ public class AreaDto {
 			areaInfo.ri = area.getRi();
 			return areaInfo;
 		}
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class AllAreaInfo {
+		private String region;
+		private List<DistrictDto> districts;
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class DistrictDto {
+		private String name;
+		private List<String> neighborhoods;
 	}
 }

--- a/src/main/java/com/hm/picplz/domain/area/repository/AreaRepository.java
+++ b/src/main/java/com/hm/picplz/domain/area/repository/AreaRepository.java
@@ -2,6 +2,8 @@ package com.hm.picplz.domain.area.repository;
 
 import java.util.List;
 
+import com.hm.picplz.domain.area.dto.AllAreaInfoProjection;
+import com.hm.picplz.domain.area.dto.AreaDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -27,4 +29,20 @@ public interface AreaRepository extends JpaRepository<Area, Long> {
 		nativeQuery = true
 	)
 	List<Area> searchByKeyword(@Param("keyword") String keyword);
+
+	@Query(value = """
+		SELECT DISTINCT
+			   LEFT(sido, 2) AS sido,
+			   CASE
+				   WHEN sido IN ('경기도', '제주특별자치도') THEN LEFT(sigungu, 3)
+				   ELSE sigungu
+			   END AS sigungu,
+			   eupmyeondong,
+			   area_id  -- 추가
+		   FROM area
+		   WHERE deleted_date IS NULL
+			 AND eupmyeondong IS NOT NULL
+			 AND sido IN ('서울특별시', '부산광역시', '인천광역시', '경기도', '제주특별자치도')
+		   ORDER BY area_id;""", nativeQuery = true)
+	List<AllAreaInfoProjection> findAllEupmyeondong();
 }

--- a/src/main/java/com/hm/picplz/domain/area/repository/AreaRepository.java
+++ b/src/main/java/com/hm/picplz/domain/area/repository/AreaRepository.java
@@ -29,19 +29,17 @@ public interface AreaRepository extends JpaRepository<Area, Long> {
 	)
 	List<Area> searchByKeyword(@Param("keyword") String keyword);
 
-	@Query(value = """
-		SELECT
-			   LEFT(sido, 2) AS sido,
-			   CASE
-				   WHEN sido IN ('경기도', '제주특별자치도') THEN LEFT(sigungu, 3)
-				   ELSE sigungu
-			   END AS sigungu,
-			   eupmyeondong,
-			   area_id
-		   FROM area
-		   WHERE deleted_date IS NULL
-			 AND eupmyeondong IS NOT NULL
-			 AND sido IN ('서울특별시', '부산광역시', '인천광역시', '경기도', '제주특별자치도')
-		   ORDER BY area_id;""", nativeQuery = true)
+	@Query(value =
+		"""
+			SELECT
+      		LEFT(sido, 2) AS sido,
+      		IF(sido IN ('경기도', '제주특별자치도'), LEFT(sigungu, 3), sigungu) AS sigungu,
+      		JSON_ARRAYAGG(eupmyeondong) AS neighborhoods
+  			FROM area
+			WHERE deleted_date IS NULL
+    			AND eupmyeondong IS NOT NULL
+    			AND sido IN ('서울특별시', '부산광역시', '인천광역시', '경기도', '제주특별자치도')
+  			GROUP BY sido, sigungu;
+		""", nativeQuery = true)
 	List<AllAreaInfoProjection> findAllEupmyeondong();
 }

--- a/src/main/java/com/hm/picplz/domain/area/repository/AreaRepository.java
+++ b/src/main/java/com/hm/picplz/domain/area/repository/AreaRepository.java
@@ -3,7 +3,6 @@ package com.hm.picplz.domain.area.repository;
 import java.util.List;
 
 import com.hm.picplz.domain.area.dto.AllAreaInfoProjection;
-import com.hm.picplz.domain.area.dto.AreaDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -31,14 +30,14 @@ public interface AreaRepository extends JpaRepository<Area, Long> {
 	List<Area> searchByKeyword(@Param("keyword") String keyword);
 
 	@Query(value = """
-		SELECT DISTINCT
+		SELECT
 			   LEFT(sido, 2) AS sido,
 			   CASE
 				   WHEN sido IN ('경기도', '제주특별자치도') THEN LEFT(sigungu, 3)
 				   ELSE sigungu
 			   END AS sigungu,
 			   eupmyeondong,
-			   area_id  -- 추가
+			   area_id
 		   FROM area
 		   WHERE deleted_date IS NULL
 			 AND eupmyeondong IS NOT NULL

--- a/src/main/java/com/hm/picplz/domain/area/service/AreaService.java
+++ b/src/main/java/com/hm/picplz/domain/area/service/AreaService.java
@@ -1,8 +1,13 @@
 package com.hm.picplz.domain.area.service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hm.picplz.domain.area.dto.AllAreaInfoProjection;
 import org.springframework.stereotype.Service;
 
@@ -17,15 +22,18 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class AreaService {
+
 	private final AreaRepository areaRepository;
+	private final ObjectMapper objectMapper;
 
 	static final double EARTH_RADIUS = 111;
 
 	/**
 	 * 사용자의 현재 위치 근처의 법정동을 반환합니다.
+	 *
 	 * @param radius km 단위의 범위
-	 * @param lat 위도
-	 * @param lng 경도
+	 * @param lat    위도
+	 * @param lng    경도
 	 * @return 근처 법정동 최대 10개
 	 */
 	public List<AreaDto.AreaInfo> getNearbyAreas(int radius, double lat, double lng) {
@@ -37,44 +45,57 @@ public class AreaService {
 		double lngDiff = radius / (EARTH_RADIUS * Math.cos(Math.toRadians(lat)));
 
 		List<Area> nearAreas = areaRepository.findAreaInMBR(
-			lat-latDiff, lng-lngDiff, lat+latDiff, lng+lngDiff
+				lat - latDiff, lng - lngDiff, lat + latDiff, lng + lngDiff
 		);
 
 		return nearAreas.stream()
-			.map(AreaDto.AreaInfo::from)
-			.toList();
+				.map(AreaDto.AreaInfo::from)
+				.toList();
 	}
 
 	/**
 	 * 법정동을 키워드로 검색합니다.
+	 *
 	 * @param keyword 검색 키워드
 	 * @return 해당 키워드를 포함하는 법정동 최대 10개
 	 */
 	public List<AreaDto.AreaInfo> searchAreasWithKeyword(String keyword) {
 		return areaRepository.searchByKeyword(keyword).stream()
-			.map(AreaDto.AreaInfo::from)
-			.toList();
+				.map(AreaDto.AreaInfo::from)
+				.toList();
 	}
 
 	/**
-	 * 모든 법정동을 조회합니다.
-	 * 임시) 서울, 경기, 인천, 부산, 제주만 검색
+	 * 서울, 경기, 인천, 부산, 제주의 법정동을 조회합니다.
 	 * @return 모든 법정동 데이터
 	 */
+	//TODO: 캐시 조회로 변경
 	public List<AreaDto.AllAreaInfo> getAllAreas() {
 		List<AllAreaInfoProjection> result = areaRepository.findAllEupmyeondong();
+		Map<String, List<AreaDto.DistrictDto>> tmpMap = new HashMap<>(); // region : List<districtDto> 매핑
+		// region : 서울, 부산 .. , districts : name, neighborhoods , districtDto.name : 강남구 .. , districtDto : 논현동 ..
 
-		return result.stream()
-				.collect(Collectors.groupingBy(AllAreaInfoProjection::getSido,
-						Collectors.groupingBy(AllAreaInfoProjection::getSigungu,
-								Collectors.mapping(AllAreaInfoProjection::getEupmyeondong, Collectors.toList()))))
-				.entrySet().stream()
-				.map(regionEntry -> new AreaDto.AllAreaInfo(
-						regionEntry.getKey(),
-						regionEntry.getValue().entrySet().stream()
-								.map(districtEntry -> new AreaDto.DistrictDto(districtEntry.getKey(), districtEntry.getValue()))
-								.toList()
-				))
-				.toList();
+		for (AllAreaInfoProjection item : result) { // 서울 / 강남구 / 수서동, 개포동, 도곡동 ..
+			List<String> neighborhoods;
+			try {
+				neighborhoods = new ArrayList<>(objectMapper.readValue(
+                        item.getNeighborhoods(), new TypeReference<List<String>>() {
+                        })); // 해당 시군구의 모든 동 담기
+			} catch (JsonProcessingException e) {
+				throw new RuntimeException(e);
+			}
+
+			// 하나의 시군구에 모든 동 담기
+			AreaDto.DistrictDto district = new AreaDto.DistrictDto(item.getSigungu(), neighborhoods);
+			// 임시 맵에 시도:시군구-동 리스트 삽입
+			tmpMap.computeIfAbsent(item.getSido(), k -> new ArrayList<>()).add(district);
+		}
+
+		List<AreaDto.AllAreaInfo> response = new ArrayList<>();
+		for (String region : tmpMap.keySet()) { // 맵으로 담아뒀던 거 List롤 변환하여 반환
+			response.add(new AreaDto.AllAreaInfo(region, tmpMap.get(region)));
+		}
+
+		return response;
 	}
 }

--- a/src/main/java/com/hm/picplz/domain/area/service/AreaService.java
+++ b/src/main/java/com/hm/picplz/domain/area/service/AreaService.java
@@ -1,7 +1,6 @@
 package com.hm.picplz.domain.area.service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.hm.picplz.domain.area.dto.AllAreaInfoProjection;
@@ -66,24 +65,16 @@ public class AreaService {
 		List<AllAreaInfoProjection> result = areaRepository.findAllEupmyeondong();
 
 		return result.stream()
-				.collect(Collectors.groupingBy(AllAreaInfoProjection::getSido))  // 지역별로 묶음
+				.collect(Collectors.groupingBy(AllAreaInfoProjection::getSido,
+						Collectors.groupingBy(AllAreaInfoProjection::getSigungu,
+								Collectors.mapping(AllAreaInfoProjection::getEupmyeondong, Collectors.toList()))))
 				.entrySet().stream()
-				.map(regionEntry -> {
-					String region = regionEntry.getKey(); // ex) 서울, 경기 등
-					Map<String, List<AllAreaInfoProjection>> districtGrouped = regionEntry.getValue().stream()
-							.collect(Collectors.groupingBy(AllAreaInfoProjection::getSigungu)); // 구/시로 묶기
-
-					List<AreaDto.DistrictDto> districts = districtGrouped.entrySet().stream()
-							.map(districtEntry -> new AreaDto.DistrictDto(
-									districtEntry.getKey(),
-									districtEntry.getValue().stream()
-											.map(AllAreaInfoProjection::getEupmyeondong)
-											.toList()
-							))
-							.toList();
-
-					return new AreaDto.AllAreaInfo(region, districts);
-				})
+				.map(regionEntry -> new AreaDto.AllAreaInfo(
+						regionEntry.getKey(),
+						regionEntry.getValue().entrySet().stream()
+								.map(districtEntry -> new AreaDto.DistrictDto(districtEntry.getKey(), districtEntry.getValue()))
+								.toList()
+				))
 				.toList();
 	}
 }

--- a/src/main/java/com/hm/picplz/domain/area/service/AreaService.java
+++ b/src/main/java/com/hm/picplz/domain/area/service/AreaService.java
@@ -1,7 +1,10 @@
 package com.hm.picplz.domain.area.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import com.hm.picplz.domain.area.dto.AllAreaInfoProjection;
 import org.springframework.stereotype.Service;
 
 import com.hm.picplz.domain.area.domain.Area;
@@ -52,5 +55,36 @@ public class AreaService {
 		return areaRepository.searchByKeyword(keyword).stream()
 			.map(AreaDto.AreaInfo::from)
 			.toList();
+	}
+
+	/**
+	 * 모든 법정동을 조회합니다.
+	 * 임시) 서울, 경기, 인천, 부산, 제주만 검색
+	 * @return 모든 법정동 데이터
+	 */
+	public List<AreaDto.AllAreaInfo> getAllAreas() {
+		List<AllAreaInfoProjection> result = areaRepository.findAllEupmyeondong();
+
+		return result.stream()
+				.collect(Collectors.groupingBy(AllAreaInfoProjection::getSido))  // 지역별로 묶음
+				.entrySet().stream()
+				.map(regionEntry -> {
+					String region = regionEntry.getKey(); // ex) 서울, 경기 등
+					Map<String, List<AllAreaInfoProjection>> districtGrouped = regionEntry.getValue().stream()
+							.collect(Collectors.groupingBy(AllAreaInfoProjection::getSigungu)); // 구/시로 묶기
+
+					List<AreaDto.DistrictDto> districts = districtGrouped.entrySet().stream()
+							.map(districtEntry -> new AreaDto.DistrictDto(
+									districtEntry.getKey(),
+									districtEntry.getValue().stream()
+											.map(AllAreaInfoProjection::getEupmyeondong)
+											.distinct()
+											.toList()
+							))
+							.toList();
+
+					return new AreaDto.AllAreaInfo(region, districts);
+				})
+				.toList();
 	}
 }

--- a/src/main/java/com/hm/picplz/domain/area/service/AreaService.java
+++ b/src/main/java/com/hm/picplz/domain/area/service/AreaService.java
@@ -78,7 +78,6 @@ public class AreaService {
 									districtEntry.getKey(),
 									districtEntry.getValue().stream()
 											.map(AllAreaInfoProjection::getEupmyeondong)
-											.distinct()
 											.toList()
 							))
 							.toList();

--- a/src/main/java/com/hm/picplz/domain/auth/service/AppleTokenService.java
+++ b/src/main/java/com/hm/picplz/domain/auth/service/AppleTokenService.java
@@ -34,7 +34,7 @@ public class AppleTokenService {
     private String cid; // iOS 앱의 Bundle ID
 
     private final WebClientService webClientService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
     private final Map<String, PublicKey> keyCache = new ConcurrentHashMap<>();
 
     /**

--- a/src/main/java/com/hm/picplz/global/config/JacksonConfig.java
+++ b/src/main/java/com/hm/picplz/global/config/JacksonConfig.java
@@ -1,0 +1,22 @@
+package com.hm.picplz.global.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+}


### PR DESCRIPTION
# 💡 PR Summary - 전국 읍면동 조회 API 구현
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- 캐싱, 배치 작업은 시간이 걸릴 것 같아서 DB 조회를 우선으로 API 구현
- 기획에 나와있는 서울, 제주, 부산, 인천, 경기 지역 조회
  - 서울, 인천, 부산은 시 - 구 - 동
  - 제주, 경기는 지역 - 시 - 동
- 아래와 같은 응답으로 리턴
```
[
  {
    "region": "서울",
    "districts": [
      {
        "name": "강남구",
        "neighborhoods": ["신사동", "논현동", "압구정동", "청담동"]
      },
      {
        "name": "강동구",
        "neighborhoods": ["천호동", "명일동", "고덕동"]
      },
      // … 나머지 구군
    ]
  },
  {
    "region": "경기",
    "districts": [
      {
        "name": "성남시",
        "neighborhoods": ["분당동", "정자동"]
      }
    ]
  },
]
```

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
feat/all-area

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- close #84 
